### PR TITLE
Upgrade issue and PR templates per current ddev versions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What happened (or feature request):
+
+
+## What you expected to happen:
+
+
+## How to reproduce it (as minimally and precisely as possible):
+
+
+## Anything else do we need to know:
+
+
+## Related source links or issues:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## The Problem:
+
+## The Fix:
+
+## The Test:
+
+## Automation Overview:
+<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
+
+## Related Issue Link(s):
+
+## Release/Deployment notes:
+<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
+


### PR DESCRIPTION
This trivial PR just adds our current .github templates to this repo. There is no risk and no functionality change.