### PR TITLE
Move test into Makefile, don't hand-code in circle.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ include build-tools/makefile_components/base_container.mak
 include build-tools/makefile_components/base_push.mak
 #include build-tools/makefile_components/base_test_go.mak
 include build-tools/makefile_components/base_test_python.mak
+
+test: container
+	docker run -it $(awk {'print $1'} .docker_image)  php --version | grep "^PHP 7"

--- a/circle.yml
+++ b/circle.yml
@@ -9,4 +9,3 @@ dependencies:
 test:
     override:
         - make test
-        - docker run -it $(awk {'print $1'} .docker_image)  php --version | grep "^PHP 7"


### PR DESCRIPTION
## The Problem:

We need to be able to use "make test" for a master build, but the little bit of test functionality was bundled explicitly into the circle.yml.

## The Fix:

Move the (trivial) test functionality out of circle.yml and into the Makefile.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

This is done in support of [create master build for ddev, ddev/106](https://github.com/drud/ddev/issues/106)

Deployment:
- [ ] Tag/push a new release in git (v0.2.0)
- [ ] Build/push the new release `make push`
- [x] Update docker.nginx-php-fpm with the new release.
