### PR TITLE
Don't hide the php failure behind a grep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,5 @@ include build-tools/makefile_components/base_push.mak
 include build-tools/makefile_components/base_test_python.mak
 
 test: container
+	docker run -it --rm $(DOCKER_REPO):$(VERSION)  php --version
 	docker run -it --rm $(DOCKER_REPO):$(VERSION)  php --version | grep "^PHP 7"

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,5 @@ include build-tools/makefile_components/base_test_python.mak
 
 test: container
 	docker run -it --rm $(DOCKER_REPO):$(VERSION)  php --version
+	echo $$?
 	docker run -it --rm $(DOCKER_REPO):$(VERSION)  php --version | grep "^PHP 7"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,4 @@ include build-tools/makefile_components/base_push.mak
 include build-tools/makefile_components/base_test_python.mak
 
 test: container
-	docker run -it --rm $(DOCKER_REPO):$(VERSION)  php --version
-	echo $$?
-	docker run -it --rm $(DOCKER_REPO):$(VERSION)  php --version | grep "^PHP 7"
+	docker run --rm $(DOCKER_REPO):$(VERSION)  php --version


### PR DESCRIPTION
## The Problem:

I'm having occasional failures of the one-liner test in make test. I'd like to be able to see what the "grep" is filtering out.

## The Fix:

Add a line to the `make test` that doesn't explicitly look for "PHP 7"

This should have no impact on any operations, and does no harm.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

